### PR TITLE
Fix table of contents width

### DIFF
--- a/assets/stylesheets/bootstrap-docs.css
+++ b/assets/stylesheets/bootstrap-docs.css
@@ -1087,7 +1087,3 @@ h1[id] {
   color: #cdbfe3;
   background-color: #563d7c;
 }
-
-#toc {
-  width: 275px;
-}


### PR DESCRIPTION
This line causes the table of contents to bleed into the content area under Bootstrap's medium breakpoint (>= 992px and < 1200px).

![screen-shot-2014-06-14-at-11 07 39-pm](https://cloud.githubusercontent.com/assets/625922/3280107/ff0e7e60-f443-11e3-8841-30f44f49f6e0.png)
