### PR TITLE
fix typos

### DIFF
--- a/articles/advanced_options.md
+++ b/articles/advanced_options.md
@@ -42,9 +42,9 @@ to instantiate the policy:
 (cp/exponential-reconnection-policy 100 1000)
 ```
 
-### Constant reconnectoin policy
+### Constant reconnection policy
 
-Constant reconnectoin policy waits for the fixed period of time
+Constant reconnection policy waits for the fixed period of time
 between reconnection attempts.
 
 `clojurewerkz.cassaforte.policies/constant-reconnection-policy` is used
@@ -52,7 +52,7 @@ to instantiate the policy:
 
 
 ```clojure
-(client/constant-reconnection-policy 100)
+(cp/constant-reconnection-policy 100)
 ```
 
 The policy above will wait for 100 milliseconds between reconnection
@@ -114,7 +114,7 @@ level for query to succeed. It will retry queries in two cases:
   * __on timed out read__, if enough replicas responded, but data still was not retrieved, which
     usually means that some of the nodes chosen by coordinator are dead but were not detected
     as such just yet.
-  * __on timed out write__, only if it occured during writing to distributed batch log. It is very likely that
+  * __on timed out write__, only if it occurred during writing to distributed batch log. It is very likely that
     coordinator picked unresponsive nodes that were not yet detected as dead.
 
 Use `clojurewerkz.cassaforte.policies/retry-policy` to pick a policy by name:
@@ -129,7 +129,7 @@ Use `clojurewerkz.cassaforte.policies/retry-policy` to pick a policy by name:
 
 Under some circumstances, it makes sense to tune the consistency level
 for the subsequent write. This sacrifices consistency for
-availability. Operation will still be considered as sucessful, even
+availability. Operation will still be considered as successful, even
 though smaller amount of replicas were used for the operation.
 
 For cases like that, you may use the downgrading policy. It will retry query:
@@ -142,9 +142,9 @@ For cases like that, you may use the downgrading policy. It will retry query:
   * if coordinator node notices that there's __not enough replicas__ alive to satisfy query, execute
     same query with lower consistency level.
 
-This policy should only be used when tradeoff of writing data to the
+This policy should only be used when trade-off of writing data to the
 smaller amount of nodes is acceptable. Also, that sometimes data won't
-be even possible to read that way, because tradeoff was made and
+be even possible to read that way, because trade-off was made and
 guarantees have changed. Reads with lower consistency level may
 increase chance of reading stale data.
 

--- a/articles/cassandra_concepts.md
+++ b/articles/cassandra_concepts.md
@@ -90,7 +90,7 @@ evenly distributed between them.
 
 This can be split into two parts: _Service Discovery_ and _Failure
 Detection_.  Service discovery comes into play when you set up a
-fresh node, add it to the cluster.  data gets replicated to that
+fresh node, add it to the cluster.  Data gets replicated to that
 node and it starts receiving requests.  When the node is was taken
 down for maintenance, or fails due to an error, this should be
 detected as quickly as possible by other members of the cluster.
@@ -110,7 +110,7 @@ If you're familiar with Cassandra, you may want to skip this section.
 __Keyspace__ is what's usually called database in relational
 databases, it holds column families, sets of key-value pairs. __Column
 family__ is somewhat close to the table concept from relational
-DBs. There're no relations between column families in Cassandra, even
+DBs. There are no relations between column families in Cassandra, even
 though it is possible to use foreign keys, _there will be no
 referencial integrity checks performed_.
 

--- a/articles/cql.md
+++ b/articles/cql.md
@@ -12,7 +12,7 @@ This guide covers most CQL operations, such as
   * Ordering
   * Collection Types
   * Counter Columns
-  * Timestampls and TTL
+  * Timestamps and TTL
   * Prepared Statements
   * Range queries
   * Pagination
@@ -289,7 +289,7 @@ Available consistency levels are:
 Please refer to [Cassandra documentation on consistency levels](http://www.datastax.com/documentation/cassandra/2.1/cassandra/dml/dml_config_consistency_c.html)
 for more info.
 
-Following operation will be performed with consistenct level of `:quorum`:
+The following operation will be performed with consistency level of `:quorum`:
 
 ``` clojure
 (ns cassaforte.docs
@@ -808,7 +808,7 @@ column provides an efficient way to count or sum integer values. It is
 achieved by using atomic increment/decrement operations on column values.
 
 Counter is a special column type, whose value is a 64-bit (signed)
-interger. On write, new value is added (or substracted) to previous
+integer. On write, new value is added (or subtracted) to previous
 counter value. It should be noted that usual consistency/availability
 tradeoffs apply to counter operations. In order to perform a counter
 update, Cassandra has to perform a read before write in a background,

--- a/articles/guides.md
+++ b/articles/guides.md
@@ -25,7 +25,7 @@ Covers CQL operations besides schema manipulation:
   * Ordering
   * Collection Types
   * Counter Columns
-  * Timestampls and TTL
+  * Timestamps and TTL
   * Prepared Statements
   * Range queries
   * Pagination


### PR DESCRIPTION
I found a bunch of typos in the docs, so I fixed them.
